### PR TITLE
Remove includeDependencies directive.

### DIFF
--- a/ftw/casauth/configure.zcml
+++ b/ftw/casauth/configure.zcml
@@ -6,7 +6,5 @@
     i18n_domain="ftw.casauth">
 
   <five:registerPackage package="." initialize=".initialize" />
-
-  <includeDependencies package="." />
-
+    
 </configure>


### PR DESCRIPTION
There is no need for ``includeDependencies``: it is time consuming and does do any good, since this package has no dependencies without autoinclude entry point.