### PR TITLE
REST API login

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,11 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Add plone.restapi endpoint for login.
+  [buchi]
+
 - Add Plone 5 compatibility. [phgross]
+
 
 1.1.0 (2016-10-13)
 ------------------

--- a/ftw/casauth/configure.zcml
+++ b/ftw/casauth/configure.zcml
@@ -2,9 +2,11 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:i18n="http://namespaces.zope.org/i18n"
-    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.casauth">
 
   <five:registerPackage package="." initialize=".initialize" />
-    
+
+  <include package=".restapi" zcml:condition="installed plone.restapi"/>
+
 </configure>

--- a/ftw/casauth/restapi/caslogin.py
+++ b/ftw/casauth/restapi/caslogin.py
@@ -21,6 +21,11 @@ class CASLogin(Service):
                 type='Missing service ticket',
                 message='Service ticket must be provided in body.'))
 
+        if 'service' in data:
+            service = data['service']
+        else:
+            service = service_url(self.request)[:-10],  # Strip `/@caslogin`
+
         # Disable CSRF protection
         if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):
             alsoProvides(self.request,
@@ -46,7 +51,7 @@ class CASLogin(Service):
         userid = validate_ticket(
             data['ticket'],
             cas_plugin.cas_server_url,
-            service_url(self.request),
+            service,
         )
 
         user = uf.getUserById(userid)

--- a/ftw/casauth/restapi/caslogin.py
+++ b/ftw/casauth/restapi/caslogin.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from ftw.casauth.cas import service_url
+from ftw.casauth.cas import validate_ticket
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from Products.CMFCore.utils import getToolByName
+from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin  # noqa
+from zope.interface import alsoProvides
+
+import plone.protect.interfaces
+
+
+class CASLogin(Service):
+    """Handles login and returns a JSON web token (JWT).
+    """
+    def reply(self):
+        data = json_body(self.request)
+        if 'ticket' not in data:
+            self.request.response.setStatus(400)
+            return dict(error=dict(
+                type='Missing service ticket',
+                message='Service ticket must be provided in body.'))
+
+        # Disable CSRF protection
+        if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):
+            alsoProvides(self.request,
+                         plone.protect.interfaces.IDisableCSRFProtection)
+
+        uf = getToolByName(self.context, 'acl_users')
+        plugins = uf._getOb('plugins')
+        authenticators = plugins.listPlugins(IAuthenticationPlugin)
+        cas_plugin = None
+        jwt_plugin = None
+        for id_, authenticator in authenticators:
+            if authenticator.meta_type == "CAS Authentication Plugin":
+                cas_plugin = authenticator
+            elif authenticator.meta_type == "JWT Authentication Plugin":
+                jwt_plugin = authenticator
+
+        if cas_plugin is None or jwt_plugin is None:
+            self.request.response.setStatus(501)
+            return dict(error=dict(
+                type='Login failed',
+                message='CAS/JWT authentication plugin not installed.'))
+
+        userid = validate_ticket(
+            data['ticket'],
+            cas_plugin.cas_server_url,
+            service_url(self.request),
+        )
+
+        user = uf.getUserById(userid)
+        payload = {'fullname': user.getProperty('fullname')}
+        return {
+            'token': jwt_plugin.create_token(userid, data=payload)
+        }
+
+    def check_permission(self):
+        return

--- a/ftw/casauth/restapi/configure.zcml
+++ b/ftw/casauth/restapi/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="ftw.casauth">
+
+  <plone:service
+      method="POST"
+      name="@caslogin"
+      for="*"
+      factory=".caslogin.CASLogin"
+      permission="zope.Public"
+      />
+
+</configure>

--- a/ftw/casauth/testing.py
+++ b/ftw/casauth/testing.py
@@ -1,10 +1,12 @@
+from ftw.casauth.plugin import CASAuthenticationPlugin
+from ftw.testbrowser import TRAVERSAL_BROWSER_FIXTURE
+from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
 from zope.configuration import xmlconfig
-from ftw.casauth.plugin import CASAuthenticationPlugin
 
 
 class FtwCasauthLayer(PloneSandboxLayer):
@@ -13,12 +15,19 @@ class FtwCasauthLayer(PloneSandboxLayer):
 
     def setUpZope(self, app, configurationContext):
         # Load ZCML
+        import plone.restapi
+        xmlconfig.file(
+            'configure.zcml',
+            plone.restapi,
+            context=configurationContext
+        )
         import ftw.casauth
         xmlconfig.file(
             'configure.zcml',
             ftw.casauth,
             context=configurationContext
         )
+        z2.installProduct(app, 'plone.restapi')
         z2.installProduct(app, 'ftw.casauth')
 
     def setUpPloneSite(self, portal):
@@ -35,10 +44,12 @@ class FtwCasauthLayer(PloneSandboxLayer):
             'IExtractionPlugin',
         ])
         self['plugin'] = plugin
+        applyProfile(portal, 'plone.restapi:default')
+
 
 FTW_CASAUTH_FIXTURE = FtwCasauthLayer()
 FTW_CASAUTH_INTEGRATION_TESTING = IntegrationTesting(
-    bases=(FTW_CASAUTH_FIXTURE,),
+    bases=(FTW_CASAUTH_FIXTURE, TRAVERSAL_BROWSER_FIXTURE),
     name="FtwcasauthLayer:Integration"
 )
 FTW_CASAUTH_FUNCTIONAL_TESTING = FunctionalTesting(

--- a/ftw/casauth/tests/test_plugin.py
+++ b/ftw/casauth/tests/test_plugin.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from DateTime import DateTime
 from datetime import datetime
+from ftw.casauth.cas import service_url
 from ftw.casauth.testing import FTW_CASAUTH_INTEGRATION_TESTING
 from ftw.testing import freeze
 from mock import patch
@@ -89,9 +90,9 @@ class TestCASAuthPlugin(unittest.TestCase):
             (('ticket', 'ST-001-abc'), ('param1', 'v1'), ('param2', 'v2')))
         self.request.form.update(params)
         self.request.environ['QUERY_STRING'] = urlencode(params)
-        service_url = self.plugin._service_url(self.request)
+        url = service_url(self.request)
 
-        self.assertEqual('http://nohost?param1=v1&param2=v2', service_url)
+        self.assertEqual('http://nohost?param1=v1&param2=v2', url)
 
     @patch('ftw.casauth.plugin.validate_ticket')
     def test_authenticate_credentials_succeeds_with_valid_credentials(self, mock_validate_ticket):

--- a/ftw/casauth/tests/test_restapi.py
+++ b/ftw/casauth/tests/test_restapi.py
@@ -1,0 +1,61 @@
+from ftw.casauth.testing import FTW_CASAUTH_INTEGRATION_TESTING
+from ftw.testbrowser import browsing
+from mock import patch
+from plone.app.testing import TEST_USER_ID
+
+import json
+import unittest
+
+
+class TestCASLogin(unittest.TestCase):
+
+    layer = FTW_CASAUTH_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    @browsing
+    def test_missing_ticket_returns_400(self, browser):
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(
+                self.portal.absolute_url() + '/@caslogin',
+                method='POST',
+                headers={'Accept': 'application/json'},
+            )
+        self.assertEqual(browser.status_code, 400)
+        self.assertEqual(
+            browser.json[u'error'][u'type'], u'Missing service ticket')
+
+    @browsing
+    def test_missing_plugin_returns_501(self, browser):
+        self.portal.acl_users._delOb('cas_auth')
+        with browser.expect_http_error(code=501, reason='Not Implemented'):
+            browser.open(
+                self.portal.absolute_url() + '/@caslogin',
+                data=json.dumps({
+                    "ticket": "12345",
+                }),
+                method='POST',
+                headers={'Accept': 'application/json',
+                         'Content-Type': 'application/json'},
+            )
+        self.assertEqual(browser.status_code, 501)
+        self.assertEqual(
+            browser.json[u'error'][u'message'],
+            u'CAS/JWT authentication plugin not installed.')
+
+    @browsing
+    def test_valid_ticket_returns_jwt_token(self, browser):
+        with patch('ftw.casauth.restapi.caslogin.validate_ticket') as mock:
+            mock.return_value = TEST_USER_ID
+            browser.open(
+                self.portal.absolute_url() + '/@caslogin',
+                data=json.dumps({
+                    "ticket": "12345",
+                }),
+                method='POST',
+                headers={'Accept': 'application/json',
+                         'Content-Type': 'application/json'},
+            )
+        self.assertEqual(browser.status_code, 200)
+        self.assertIn(u'token', browser.json)

--- a/ftw/casauth/tests/test_restapi.py
+++ b/ftw/casauth/tests/test_restapi.py
@@ -59,3 +59,22 @@ class TestCASLogin(unittest.TestCase):
             )
         self.assertEqual(browser.status_code, 200)
         self.assertIn(u'token', browser.json)
+
+    @browsing
+    def test_accepts_service_url_from_body(self, browser):
+        with patch('ftw.casauth.restapi.caslogin.validate_ticket') as mock:
+            mock.return_value = TEST_USER_ID
+            browser.open(
+                self.portal.absolute_url() + '/@caslogin',
+                data=json.dumps({
+                    "ticket": "12345",
+                    "service": "http://myhost/#test",
+                }),
+                method='POST',
+                headers={'Accept': 'application/json',
+                         'Content-Type': 'application/json'},
+            )
+        self.assertEqual(browser.status_code, 200)
+        self.assertIn(u'token', browser.json)
+        mock.assert_called_with(
+            u'12345', 'https://cas.domain.net', u'http://myhost/#test')

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ version = '1.1.1.dev0'
 
 tests_require = [
     'plone.app.testing',
+    'plone.restapi',
     'mock',
+    'ftw.testbrowser',
     'ftw.testing',
 ]
 

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -3,3 +3,6 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
 
 package-name = ftw.casauth
+
+[versions]
+plone.schema = 1.2.0


### PR DESCRIPTION
Provides a new endpoint `@caslogin`.
The endpoint expects a JSON object containing the service ticket in a POST request and returns a JWT token that can be used to authenticate further requests.