### PR TITLE
Preserve multi-valued QS params when stripping ticket from service URL.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Preserve multi-valued QS params when stripping ticket from service URL. [lgraf]
 
 
 1.3.0 (2020-06-02)

--- a/ftw/casauth/cas.py
+++ b/ftw/casauth/cas.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from ftw.casauth.config import USE_CUSTOM_HTTPS_HANDLER
 from logging import getLogger
 from urllib import urlencode
@@ -88,9 +87,8 @@ def strip_ticket(url):
     but preserve everything else.
     """
     scheme, netloc, path, query, fragment = urlsplit(url)
-    # Using OrderedDict and parse_qsl here to preserve order
-    qs_params = OrderedDict(parse_qsl(query))
-    qs_params.pop('ticket', None)
+    # Using parse_qsl here to preserve order
+    qs_params = filter(lambda (k, v): k != 'ticket', parse_qsl(query))
     query = urlencode(qs_params)
     new_url = urlunsplit((scheme, netloc, path, query, fragment))
     return new_url

--- a/ftw/casauth/tests/test_cas.py
+++ b/ftw/casauth/tests/test_cas.py
@@ -1,9 +1,11 @@
-import unittest
+from ftw.casauth.cas import strip_ticket
+from ftw.casauth.cas import validate_ticket
+from ftw.casauth.tests.utils import get_data
 from ftw.casauth.tests.utils import MockRequest
 from ftw.casauth.tests.utils import MockResponse
-from ftw.casauth.tests.utils import get_data
-from ftw.casauth.cas import validate_ticket
 from mock import patch
+
+import unittest
 
 
 class TestValdidateTicket(unittest.TestCase):
@@ -45,3 +47,21 @@ class TestValdidateTicket(unittest.TestCase):
             'ST-001-abc',
             'https://cas.domain.net',
             'https://service.domain.net'))
+
+
+class TestStripTicket(unittest.TestCase):
+
+    def test_strip_ticket_drops_ticket_from_url(self):
+        url = 'http://example.org?ticket=ST-001-abc&param1=v1&param2=v2'
+        stripped = strip_ticket(url)
+        self.assertEqual('http://example.org?param1=v1&param2=v2', stripped)
+
+    def test_strip_ticket_preserves_multi_valued_params(self):
+        url = 'http://example.org?ticket=ST-001-abc&multi=v1&multi=v2'
+        stripped = strip_ticket(url)
+        self.assertEqual('http://example.org?multi=v1&multi=v2', stripped)
+
+    def test_strip_ticket_preserves_zope_style_multi_valued_params(self):
+        url = 'http://example.org?ticket=ST-001-abc&multi:list=v1&multi:list=v2'
+        stripped = strip_ticket(url)
+        self.assertEqual('http://example.org?multi%3Alist=v1&multi%3Alist=v2', stripped)

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -3,3 +3,7 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
 
 package-name = ftw.casauth
+
+[versions]
+jsonschema = 2.6.0
+PyJWT = 1.7.1

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -5,4 +5,6 @@ extends =
 package-name = ftw.casauth
 
 [versions]
+jsonschema = 2.6.0
 plone.schema = 1.2.0
+PyJWT = 1.7.1

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -6,5 +6,4 @@ package-name = ftw.casauth
 
 [versions]
 jsonschema = 2.6.0
-plone.schema = 1.2.0
 PyJWT = 1.7.1


### PR DESCRIPTION
As suspected, `strip_ticket()` didn't properly handle multi-valued query string parameters. This was because of the intermediate use of an (ordered) dictionary, which turned out to be unnecessary.

Jira: https://4teamwork.atlassian.net/browse/CA-1453