### PR TITLE
Cookie authentication when using API

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
+- Add support for cookie based authentication when using REST API. [buchi]
 - Drop support for Python < 2.7.9. [buchi]
 - Use Python's built-in HTTPS handler which enables support for TLS 1.2 and
   uses CA certificates provided by the OS. [buchi]

--- a/ftw/casauth/plugin.py
+++ b/ftw/casauth/plugin.py
@@ -145,7 +145,8 @@ class CASAuthenticationPlugin(BasePlugin):
         if not member:
             return None
         pas = self._getPAS()
-        pas.updateCredentials(self.REQUEST, self.REQUEST.RESPONSE, userid, '')
+        pas.updateCredentials(
+            self.REQUEST, self.REQUEST.RESPONSE, member.getUserName(), '')
         return member
 
     def set_login_times(self, member):


### PR DESCRIPTION
Allows to request a Plone session cookie instead of a JWT when using REST API.

To request a session cookie, just include `"set_cookie": True` in the body