### PR TITLE
Fix login with invalid ticket

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix login with invalid ticket, which could lead to authenticate the wrong
+  user.
 
 
 1.4.0 (2021-05-27)

--- a/ftw/casauth/restapi/caslogin.py
+++ b/ftw/casauth/restapi/caslogin.py
@@ -62,7 +62,7 @@ class CASLogin(Service):
             service,
         )
 
-        user = uf.getUserById(userid)
+        user = uf.getUserById(userid) if userid else None
         if not user:
             return dict(error=dict(
                 type='Login failed',


### PR DESCRIPTION
LDAPUserFolder has an unexpected behavior:
`LDAPUserFolder.enumerateUsers(id=False)` seems to return all users and thus `acl_users.getUserById(False)` returns the first user found instead of `None`.
