### PR TITLE
Lookup users by username (login) instead of userid

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Lookup users by username (login) instead of userid. [buchi]
 
 
 1.5.0 (2023-01-23)

--- a/ftw/casauth/plugin.py
+++ b/ftw/casauth/plugin.py
@@ -105,26 +105,27 @@ class CASAuthenticationPlugin(BasePlugin):
         if extractor != self.getId():
             return None
 
-        userid = validate_ticket(
+        username = validate_ticket(
             credentials['ticket'],
             self.cas_server_url,
             credentials['service_url'],
         )
-        if not userid:
+        if not username:
             return None
+
+        pas = self._getPAS()
+        info = pas._verifyUser(pas.plugins, login=username)
+        if info is None:
+            return None
+        userid = info['id']
 
         result = self.login_user(userid)
         if not result:
             return None
 
-        return userid, userid
+        return userid, username
 
     def handle_login(self, userid):
-        pas = self._getPAS()
-        info = pas._verifyUser(pas.plugins, user_id=userid)
-        if info is None:
-            return None
-
         mtool = getToolByName(getSite(), 'portal_membership')
         member = mtool.getMemberById(userid)
         if member is None:

--- a/ftw/casauth/tests/test_plugin.py
+++ b/ftw/casauth/tests/test_plugin.py
@@ -7,6 +7,7 @@ from ftw.casauth.testing import PLONE_VERSION
 from ftw.testing import freeze
 from mock import patch
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
 from Products.CMFCore.utils import getToolByName
 from six.moves.urllib.parse import urlencode
 from zope.component.hooks import getSite
@@ -98,7 +99,7 @@ class TestCASAuthPlugin(unittest.TestCase):
 
     @patch('ftw.casauth.plugin.validate_ticket')
     def test_authenticate_credentials_succeeds_with_valid_credentials(self, mock_validate_ticket):
-        mock_validate_ticket.return_value = TEST_USER_ID
+        mock_validate_ticket.return_value = TEST_USER_NAME
         creds = {
             'extractor': self.plugin.getId(),
             'ticket': 'ST-001-abc',
@@ -108,7 +109,7 @@ class TestCASAuthPlugin(unittest.TestCase):
         self.plugin.REQUEST.RESPONSE = self.request.response
         userid, login = self.plugin.authenticateCredentials(creds)
         self.assertEqual(TEST_USER_ID, userid)
-        self.assertEqual(TEST_USER_ID, login)
+        self.assertEqual(TEST_USER_NAME, login)
 
     def test_authenticate_credentials_fails_with_wrong_extractor(self):
         creds = {
@@ -136,7 +137,7 @@ class TestCASAuthPlugin(unittest.TestCase):
     def test_sets_login_times_when_success(self, mock_validate_ticket):
         mtool = getToolByName(getSite(), 'portal_membership')
 
-        mock_validate_ticket.return_value = TEST_USER_ID
+        mock_validate_ticket.return_value = TEST_USER_NAME
         creds = {
             'extractor': self.plugin.getId(),
             'ticket': 'ST-001-abc',
@@ -153,7 +154,7 @@ class TestCASAuthPlugin(unittest.TestCase):
 
     @patch('ftw.casauth.plugin.validate_ticket')
     def test_expires_clipboard_when_success(self, mock_validate_ticket):
-        mock_validate_ticket.return_value = TEST_USER_ID
+        mock_validate_ticket.return_value = TEST_USER_NAME
         creds = {
             'extractor': self.plugin.getId(),
             'ticket': 'ST-001-abc',

--- a/ftw/casauth/tests/test_restapi.py
+++ b/ftw/casauth/tests/test_restapi.py
@@ -7,6 +7,7 @@ from ftw.testing import freeze
 from mock import patch
 from plone import api
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
 
 import json
 import unittest
@@ -92,7 +93,7 @@ class TestCASLogin(unittest.TestCase):
     @browsing
     def test_valid_ticket_returns_jwt_token(self, browser):
         with patch('ftw.casauth.restapi.caslogin.validate_ticket') as mock:
-            mock.return_value = TEST_USER_ID
+            mock.return_value = TEST_USER_NAME
             browser.open(
                 self.portal.absolute_url() + '/@caslogin',
                 data=json.dumps({
@@ -108,7 +109,7 @@ class TestCASLogin(unittest.TestCase):
     @browsing
     def test_returns_ac_cookie_if_requested(self, browser):
         with patch('ftw.casauth.restapi.caslogin.validate_ticket') as mock:
-            mock.return_value = TEST_USER_ID
+            mock.return_value = TEST_USER_NAME
             browser.open(
                 self.portal.absolute_url() + '/@caslogin',
                 data=json.dumps({
@@ -127,7 +128,7 @@ class TestCASLogin(unittest.TestCase):
     @browsing
     def test_accepts_service_url_from_body(self, browser):
         with patch('ftw.casauth.restapi.caslogin.validate_ticket') as mock:
-            mock.return_value = TEST_USER_ID
+            mock.return_value = TEST_USER_NAME
             browser.open(
                 self.portal.absolute_url() + '/@caslogin',
                 data=json.dumps({
@@ -146,7 +147,7 @@ class TestCASLogin(unittest.TestCase):
     @browsing
     def test_sets_login_times_when_success(self, browser):
         with patch('ftw.casauth.restapi.caslogin.validate_ticket') as mock:
-            mock.return_value = TEST_USER_ID
+            mock.return_value = TEST_USER_NAME
             with freeze(datetime(2016, 2, 12, 16, 40)):
                 browser.open(
                     self.portal.absolute_url() + '/@caslogin',


### PR DESCRIPTION
In current setups `login` and `userid` have the same value, thus this change shouldn't have an impact.
In the future we want the `userid` to be an internal id that's not known to external systems (LDAP, authentication portal).
Therefore we need to lookup the user by `login` (`username`).
