### PR TITLE
Fix again login with invalid ticket using REST API

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix again login with invalid ticket using REST API, which could lead to
+  authenticate the wrong user. Bug was reintroduced in 1.6.0. [buchi]
 
 
 1.6.0 (2023-08-15)

--- a/ftw/casauth/restapi/caslogin.py
+++ b/ftw/casauth/restapi/caslogin.py
@@ -61,7 +61,7 @@ class CASLogin(Service):
             cas_plugin.cas_server_url,
             service,
         )
-        info = uf._verifyUser(uf.plugins, login=username)
+        info = uf._verifyUser(uf.plugins, login=username) if username else None
         if info is None:
             self.request.response.setStatus(401)
             return dict(error=dict(


### PR DESCRIPTION
LDAPUserFolder has an unexpected behavior:
`LDAPUserFolder.enumerateUsers(id=False)` returns all users and thus `acl_users.getUserById(False)` returns the first user found instead of `None`.